### PR TITLE
FPPDF_Core::check_configuration() match by template returned index fix

### DIFF
--- a/pdf.php
+++ b/pdf.php
@@ -775,7 +775,7 @@ class FPPDF_Core extends FPPDFGenerator
 					if(isset($fppdf->configuration[$i]['template']) && $fppdf->configuration[$i]['template'] == $template)
 					{
 						/* matched by template */
-						return $fppdf->index[$form_id][$i];	
+						return $i;	
 					}
 				}				
 			}


### PR DESCRIPTION
Should just return $i as it is the index value